### PR TITLE
fix(ci): create labels before applying them in back-sync workflow

### DIFF
--- a/.github/workflows/back-sync.yml
+++ b/.github/workflows/back-sync.yml
@@ -74,6 +74,14 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Ensure labels exist
+        if: steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "back-sync" --color "1d76db" --description "Automated back-sync PR" --force
+          gh label create "automated" --color "ededed" --description "Created by automation" --force
+
       - name: Create back-sync PR
         if: steps.existing.outputs.exists == 'false'
         env:


### PR DESCRIPTION
## Summary

- Fix the back-sync workflow failure caused by `gh pr create --label` referencing labels that don't exist in the repo
- Add an idempotent "Ensure labels exist" step that creates the `back-sync` and `automated` labels (using `--force`) before the PR creation step

## Test plan

- [ ] Merge this PR into `staging` and verify the back-sync workflow succeeds (creating a PR from `staging` → `development`)
- [ ] Verify the labels `back-sync` and `automated` are created in the repo


Made with [Cursor](https://cursor.com)