### PR TITLE
ci: use tree diff instead of ancestry to skip back-sync when no changes

### DIFF
--- a/.github/workflows/back-sync.yml
+++ b/.github/workflows/back-sync.yml
@@ -42,9 +42,10 @@ jobs:
         run: |
           SOURCE="${{ steps.direction.outputs.source }}"
           git fetch origin "$SOURCE"
-          if git merge-base --is-ancestor "origin/$SOURCE" HEAD; then
+          # Skip if target already has the same tree as source (no file changes to propagate)
+          if git diff --quiet HEAD "origin/$SOURCE"; then
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
-            echo "Target already contains all commits from $SOURCE, skipping back-sync"
+            echo "Target already has same content as $SOURCE, skipping back-sync"
           else
             echo "has_diff=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Fixes the back-sync skip logic: use `git diff` to compare trees instead of `merge-base --is-ancestor` for ancestry. Skips when target and source have identical content, avoiding PRs that would merge with no file changes.

Made with [Cursor](https://cursor.com)