### PR TITLE
fix(ci): add pull-requests permission to Create Release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,6 +19,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:


### PR DESCRIPTION
Add pull-requests: write permission so gh pr create can create release PRs. Fixes 'Resource not accessible by integration' error.

Made with [Cursor](https://cursor.com)