### PR TITLE
fix(ci): use GH_PAT for Create Release PR to trigger CI checks

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Create release PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           gh label create "release" --color "0E8A16" --description "Release PR - creates tag and GitHub Release when merged" 2>/dev/null || true
           gh pr create \

--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ The token must have `repo` and `admin:repo_hook` scopes.
 
 ### 5 (manual). Configure GitHub repository secrets
 
-Add the following secret in your repo's Settings > Secrets and variables > Actions:
+Add the following secrets in your repo's Settings > Secrets and variables > Actions:
 
 - `AWS_ROLE_ARN`: The ARN of the IAM role created in step 3
+- `GH_PAT`: A GitHub Personal Access Token with `repo` scope (used by Create Release to open PRs that trigger CI). If the PAT is already in AWS Secrets Manager as `github-token`, sync it: `aws secretsmanager get-secret-value --secret-id github-token --query SecretString --output text | gh secret set GH_PAT`
 
 ### 6 (manual). Create GitHub Environments
 


### PR DESCRIPTION
## Hotfix

**Problem:** The Create Release workflow opens a PR from staging → main, but that PR never shows lint, test, or format checks. This happens because GitHub intentionally does not trigger `pull_request` workflows when the PR is created by another workflow using `GITHUB_TOKEN`—a safeguard against recursive workflow runs.

**Solution:** Use a Personal Access Token (`GH_PAT` secret) instead of `github.token` when creating the release PR. PRs created with a PAT trigger CI normally.

**Changes:**
- Update create-release.yml to use `secrets.GH_PAT`
- Document `GH_PAT` in README manual setup section

Made with [Cursor](https://cursor.com)