### PR TITLE
chore(deps): upgrade major versions (zod, graphql-codegen, commitlint, lint-staged)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "shared/schemas"
       ],
       "devDependencies": {
-        "@commitlint/cli": "^19.6.1",
-        "@commitlint/config-conventional": "^19.6.0",
+        "@commitlint/cli": "^20.0.0",
+        "@commitlint/config-conventional": "^20.0.0",
         "@eslint/js": "^9.39.3",
         "@graphql-codegen/cli": "6.1.2",
-        "@graphql-codegen/typescript": "^4.0.0",
+        "@graphql-codegen/typescript": "^5.0.0",
         "@vitest/coverage-v8": "^4.0.0",
         "eslint": "^9.39.3",
         "eslint-config-prettier": "^10.1.8",
@@ -29,7 +29,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "husky": "^9.1.7",
-        "lint-staged": "^15.4.0",
+        "lint-staged": "^16.0.0",
         "prettier": "^3.8.1",
         "typescript-eslint": "^8.56.1"
       },
@@ -2153,17 +2153,17 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
-      "integrity": "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==",
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.2.tgz",
+      "integrity": "sha512-YjYSX2yj/WsVoxh9mNiymfFS2ADbg2EK4+1WAsMuckwKMCqJ5PDG0CJU/8GvmHWcv4VRB2V02KqSiecRksWqZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^19.8.1",
-        "@commitlint/lint": "^19.8.1",
-        "@commitlint/load": "^19.8.1",
-        "@commitlint/read": "^19.8.1",
-        "@commitlint/types": "^19.8.1",
+        "@commitlint/format": "^20.4.0",
+        "@commitlint/lint": "^20.4.2",
+        "@commitlint/load": "^20.4.0",
+        "@commitlint/read": "^20.4.0",
+        "@commitlint/types": "^20.4.0",
         "tinyexec": "^1.0.0",
         "yargs": "^17.0.0"
       },
@@ -2247,27 +2247,27 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
-      "integrity": "sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==",
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.2.tgz",
+      "integrity": "sha512-rwkTF55q7Q+6dpSKUmJoScV0f3EpDlWKw2UPzklkLS4o5krMN1tPWAVOgHRtyUTMneIapLeQwaCjn44Td6OzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.8.1",
-        "conventional-changelog-conventionalcommits": "^7.0.2"
+        "@commitlint/types": "^20.4.0",
+        "conventional-changelog-conventionalcommits": "^9.1.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
-      "integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.0.tgz",
+      "integrity": "sha512-zShmKTF+sqyNOfAE0vKcqnpvVpG0YX8F9G/ZIQHI2CoKyK+PSdladXMSns400aZ5/QZs+0fN75B//3Q5CHw++w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.8.1",
+        "@commitlint/types": "^20.4.0",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -2299,13 +2299,13 @@
       "license": "MIT"
     },
     "node_modules/@commitlint/ensure": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
-      "integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.1.tgz",
+      "integrity": "sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.8.1",
+        "@commitlint/types": "^20.4.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
-      "integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
+      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2327,40 +2327,27 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
-      "integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.0.tgz",
+      "integrity": "sha512-i3ki3WR0rgolFVX6r64poBHXM1t8qlFel1G1eCBvVgntE3fCJitmzSvH5JD/KVJN/snz6TfaX2CLdON7+s4WVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.8.1",
-        "chalk": "^5.3.0"
+        "@commitlint/types": "^20.4.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/format/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@commitlint/is-ignored": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
-      "integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.1.tgz",
+      "integrity": "sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.8.1",
+        "@commitlint/types": "^20.4.0",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -2381,54 +2368,40 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
-      "integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.2.tgz",
+      "integrity": "sha512-buquzNRtFng6xjXvBU1abY/WPEEjCgUipNQrNmIWe8QuJ6LWLtei/LDBAzEe5ASm45+Q9L2Xi3/GVvlj50GAug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^19.8.1",
-        "@commitlint/parse": "^19.8.1",
-        "@commitlint/rules": "^19.8.1",
-        "@commitlint/types": "^19.8.1"
+        "@commitlint/is-ignored": "^20.4.1",
+        "@commitlint/parse": "^20.4.1",
+        "@commitlint/rules": "^20.4.2",
+        "@commitlint/types": "^20.4.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
-      "integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.0.tgz",
+      "integrity": "sha512-Dauup/GfjwffBXRJUdlX/YRKfSVXsXZLnINXKz0VZkXdKDcaEILAi9oflHGbfydonJnJAbXEbF3nXPm9rm3G6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^19.8.1",
-        "@commitlint/execute-rule": "^19.8.1",
-        "@commitlint/resolve-extends": "^19.8.1",
-        "@commitlint/types": "^19.8.1",
-        "chalk": "^5.3.0",
+        "@commitlint/config-validator": "^20.4.0",
+        "@commitlint/execute-rule": "^20.0.0",
+        "@commitlint/resolve-extends": "^20.4.0",
+        "@commitlint/types": "^20.4.0",
         "cosmiconfig": "^9.0.0",
         "cosmiconfig-typescript-loader": "^6.1.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.merge": "^4.6.2",
-        "lodash.uniq": "^4.5.0"
+        "is-plain-obj": "^4.1.0",
+        "lodash.mergewith": "^4.6.2",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@commitlint/load/node_modules/cosmiconfig": {
@@ -2477,9 +2450,9 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
-      "integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.0.tgz",
+      "integrity": "sha512-B5lGtvHgiLAIsK5nLINzVW0bN5hXv+EW35sKhYHE8F7V9Uz1fR4tx3wt7mobA5UNhZKUNgB/+ldVMQE6IHZRyA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2487,29 +2460,29 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
-      "integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.1.tgz",
+      "integrity": "sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.8.1",
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-commits-parser": "^5.0.0"
+        "@commitlint/types": "^20.4.0",
+        "conventional-changelog-angular": "^8.1.0",
+        "conventional-commits-parser": "^6.2.1"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
-      "integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.0.tgz",
+      "integrity": "sha512-QfpFn6/I240ySEGv7YWqho4vxqtPpx40FS7kZZDjUJ+eHxu3azfhy7fFb5XzfTqVNp1hNoI3tEmiEPbDB44+cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^19.8.1",
-        "@commitlint/types": "^19.8.1",
+        "@commitlint/top-level": "^20.4.0",
+        "@commitlint/types": "^20.4.0",
         "git-raw-commits": "^4.0.0",
         "minimist": "^1.2.8",
         "tinyexec": "^1.0.0"
@@ -2519,14 +2492,14 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
-      "integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.0.tgz",
+      "integrity": "sha512-ay1KM8q0t+/OnlpqXJ+7gEFQNlUtSU5Gxr8GEwnVf2TPN3+ywc5DzL3JCxmpucqxfHBTFwfRMXxPRRnR5Ki20g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^19.8.1",
-        "@commitlint/types": "^19.8.1",
+        "@commitlint/config-validator": "^20.4.0",
+        "@commitlint/types": "^20.4.0",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -2547,25 +2520,25 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
-      "integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.2.tgz",
+      "integrity": "sha512-oz83pnp5Yq6uwwTAabuVQPNlPfeD2Y5ZjMb7Wx8FSUlu4sLYJjbBWt8031Z0osCFPfHzAwSYrjnfDFKtuSMdKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^19.8.1",
-        "@commitlint/message": "^19.8.1",
-        "@commitlint/to-lines": "^19.8.1",
-        "@commitlint/types": "^19.8.1"
+        "@commitlint/ensure": "^20.4.1",
+        "@commitlint/message": "^20.4.0",
+        "@commitlint/to-lines": "^20.0.0",
+        "@commitlint/types": "^20.4.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
-      "integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
+      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2573,132 +2546,30 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
-      "integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.0.tgz",
+      "integrity": "sha512-NDzq8Q6jmFaIIBC/GG6n1OQEaHdmaAAYdrZRlMgW6glYWGZ+IeuXmiymDvQNXPc82mVxq2KiE3RVpcs+1OeDeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "find-up": "^7.0.0"
+        "escalade": "^3.2.0"
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/find-up": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
-      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^7.2.0",
-        "path-exists": "^5.0.0",
-        "unicorn-magic": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@commitlint/top-level/node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "19.8.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
-      "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.0.tgz",
+      "integrity": "sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/conventional-commits-parser": "^5.0.0",
-        "chalk": "^5.3.0"
+        "conventional-commits-parser": "^6.2.1",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=v18"
-      }
-    },
-    "node_modules/@commitlint/types/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -3556,27 +3427,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/add/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/@graphql-codegen/add/node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -3643,27 +3493,6 @@
         "@parcel/watcher": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/@graphql-hive/signal": {
@@ -4136,100 +3965,6 @@
         }
       }
     },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/schema-ast": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.0.tgz",
-      "integrity": "sha512-jn7Q3PKQc0FxXjbpo9trxzlz/GSFQWxL042l0iC8iSbM/Ar+M7uyBwMtXPsev/3Razk+osQyreghIz0d2+6F7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/typescript": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.8.tgz",
-      "integrity": "sha512-lUW6ari+rXP6tz5B0LXjmV9rEMOphoCZAkt+SJGObLQ6w6544ZsXSsRga/EJiSvZ1fRfm9yaFoErOZ56IVThyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.0",
-        "@graphql-codegen/schema-ast": "^5.0.0",
-        "@graphql-codegen/visitor-plugin-common": "6.2.3",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.3.tgz",
-      "integrity": "sha512-Rewl/QRFfIOXHFK3i/ts4VodsaB4N22kckH1zweTzq7SFodkfrqGrLa/MrGLJ/q6aUuqGiqao7f4Za2IjjkCxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/client-preset/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@graphql-codegen/client-preset/node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -4247,27 +3982,6 @@
         "@graphql-codegen/plugin-helpers": "^6.0.0",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "^10.0.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/core/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
         "tslib": "~2.6.0"
       },
       "engines": {
@@ -4304,62 +4018,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.3.tgz",
-      "integrity": "sha512-Rewl/QRFfIOXHFK3i/ts4VodsaB4N22kckH1zweTzq7SFodkfrqGrLa/MrGLJ/q6aUuqGiqao7f4Za2IjjkCxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@graphql-codegen/gql-tag-operations/node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -4368,9 +4026,9 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.1.1.tgz",
-      "integrity": "sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
+      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4396,15 +4054,18 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/schema-ast": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.1.0.tgz",
-      "integrity": "sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.0.tgz",
+      "integrity": "sha512-jn7Q3PKQc0FxXjbpo9trxzlz/GSFQWxL042l0iC8iSbM/Ar+M7uyBwMtXPsev/3Razk+osQyreghIz0d2+6F7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-codegen/plugin-helpers": "^6.0.0",
         "@graphql-tools/utils": "^10.0.0",
         "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -4437,62 +4098,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.3.tgz",
-      "integrity": "sha512-Rewl/QRFfIOXHFK3i/ts4VodsaB4N22kckH1zweTzq7SFodkfrqGrLa/MrGLJ/q6aUuqGiqao7f4Za2IjjkCxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typed-document-node/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@graphql-codegen/typed-document-node/node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -4501,15 +4106,15 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typescript": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.1.6.tgz",
-      "integrity": "sha512-vpw3sfwf9A7S+kIUjyFxuvrywGxd4lmwmyYnnDVjVE4kSQ6Td3DpqaPTy8aNQ6O96vFoi/bxbZS2BW49PwSUUA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.8.tgz",
+      "integrity": "sha512-lUW6ari+rXP6tz5B0LXjmV9rEMOphoCZAkt+SJGObLQ6w6544ZsXSsRga/EJiSvZ1fRfm9yaFoErOZ56IVThyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^5.1.0",
-        "@graphql-codegen/schema-ast": "^4.0.2",
-        "@graphql-codegen/visitor-plugin-common": "5.8.0",
+        "@graphql-codegen/plugin-helpers": "^6.1.0",
+        "@graphql-codegen/schema-ast": "^5.0.0",
+        "@graphql-codegen/visitor-plugin-common": "6.2.3",
         "auto-bind": "~4.0.0",
         "tslib": "~2.6.0"
       },
@@ -4546,100 +4151,6 @@
         }
       }
     },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.1.0.tgz",
-      "integrity": "sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/schema-ast": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.0.tgz",
-      "integrity": "sha512-jn7Q3PKQc0FxXjbpo9trxzlz/GSFQWxL042l0iC8iSbM/Ar+M7uyBwMtXPsev/3Razk+osQyreghIz0d2+6F7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/typescript": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.8.tgz",
-      "integrity": "sha512-lUW6ari+rXP6tz5B0LXjmV9rEMOphoCZAkt+SJGObLQ6w6544ZsXSsRga/EJiSvZ1fRfm9yaFoErOZ56IVThyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.0",
-        "@graphql-codegen/schema-ast": "^5.0.0",
-        "@graphql-codegen/visitor-plugin-common": "6.2.3",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.3.tgz",
-      "integrity": "sha512-Rewl/QRFfIOXHFK3i/ts4VodsaB4N22kckH1zweTzq7SFodkfrqGrLa/MrGLJ/q6aUuqGiqao7f4Za2IjjkCxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.0",
-        "@graphql-tools/optimize": "^2.0.0",
-        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
-        "dependency-graph": "^1.0.0",
-        "graphql-tag": "^2.11.0",
-        "parse-filepath": "^1.0.2",
-        "tslib": "~2.6.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript-operations/node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -4655,19 +4166,19 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.8.0.tgz",
-      "integrity": "sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.3.tgz",
+      "integrity": "sha512-Rewl/QRFfIOXHFK3i/ts4VodsaB4N22kckH1zweTzq7SFodkfrqGrLa/MrGLJ/q6aUuqGiqao7f4Za2IjjkCxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^5.1.0",
+        "@graphql-codegen/plugin-helpers": "^6.1.0",
         "@graphql-tools/optimize": "^2.0.0",
         "@graphql-tools/relay-operation-optimizer": "^7.0.0",
         "@graphql-tools/utils": "^10.0.0",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.15",
-        "dependency-graph": "^0.11.0",
+        "dependency-graph": "^1.0.0",
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
         "tslib": "~2.6.0"
@@ -8020,16 +7531,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/conventional-commits-parser": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
-      "integrity": "sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -9872,13 +9373,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/common-tags": {
@@ -9928,48 +9429,45 @@
       "license": "Apache-2.0"
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
+      "integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.1.0.tgz",
+      "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
-      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
+      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-text-path": "^2.0.0",
-        "JSONStream": "^1.3.5",
-        "meow": "^12.0.1",
-        "split2": "^4.0.0"
+        "meow": "^13.0.0"
       },
       "bin": {
-        "conventional-commits-parser": "cli.mjs"
+        "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/convert-source-map": {
@@ -10315,13 +9813,13 @@
       }
     },
     "node_modules/dependency-graph": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
-      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
+      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6.0"
+        "node": ">=4"
       }
     },
     "node_modules/dequal": {
@@ -11193,46 +10691,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execa/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -11660,19 +11118,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -11720,6 +11165,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/git-raw-commits/node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob-parent": {
@@ -12100,16 +11558,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
       }
     },
     "node_modules/husky": {
@@ -12581,6 +12029,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -12649,19 +12110,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -12695,19 +12143,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-text-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "text-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-typed-array": {
@@ -13072,33 +12507,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)",
-      "dependencies": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -13139,19 +12547,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13160,194 +12555,28 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
-      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.0.tgz",
+      "integrity": "sha512-YVHHy/p6U4/No9Af+35JLh3umJ9dPQnGTvNCbfO/T5fC60us0jFnc+vw33cqveI+kqxIFJQakcMVTO2KM+653A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
-        "commander": "^13.1.0",
-        "debug": "^4.4.0",
-        "execa": "^8.0.1",
-        "lilconfig": "^3.1.3",
-        "listr2": "^8.2.5",
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
         "micromatch": "^4.0.8",
-        "pidtree": "^0.6.0",
+        "nano-spawn": "^2.0.0",
         "string-argv": "^0.3.2",
-        "yaml": "^2.7.0"
+        "tinyexec": "^1.0.2",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.17"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/lint-staged/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/cli-truncate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/listr2": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
-      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cli-truncate": "^4.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/lint-staged/node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/listr2": {
@@ -13478,13 +12707,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -13524,13 +12746,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
       "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13803,24 +13018,17 @@
       "license": "CC0-1.0"
     },
     "node_modules/meow": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16.10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -13875,19 +13083,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-function": {
@@ -13960,6 +13155,19 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
+      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/nanoid": {
@@ -14117,35 +13325,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/nullthrows": {
@@ -14545,19 +13724,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/pngjs": {
@@ -15760,19 +14926,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -15903,26 +15056,6 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
-    },
-    "node_modules/text-extensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
-      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/timeout-signal": {
       "version": "2.0.0",
@@ -16361,19 +15494,6 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/unixify": {
       "version": "1.0.0",
@@ -17069,9 +16189,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -17088,7 +16208,7 @@
       "name": "@puzzlebottom-tabletop-tools/schemas",
       "version": "1.0.0",
       "dependencies": {
-        "zod": "^3.24.0"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "typescript": "~5.9.3",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "node": ">=24"
   },
   "devDependencies": {
-    "@commitlint/cli": "^19.6.1",
-    "@commitlint/config-conventional": "^19.6.0",
+    "@commitlint/cli": "^20.0.0",
+    "@commitlint/config-conventional": "^20.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "@eslint/js": "^9.39.3",
     "@graphql-codegen/cli": "6.1.2",
-    "@graphql-codegen/typescript": "^4.0.0",
+    "@graphql-codegen/typescript": "^5.0.0",
     "eslint": "^9.39.3",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-boundaries": "^5.4.0",
@@ -44,7 +44,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "husky": "^9.1.7",
-    "lint-staged": "^15.4.0",
+    "lint-staged": "^16.0.0",
     "prettier": "^3.8.1",
     "typescript-eslint": "^8.56.1"
   },

--- a/shared/schemas/package.json
+++ b/shared/schemas/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "zod": "^3.24.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "typescript": "~5.9.3",


### PR DESCRIPTION
Follow-up to #52. Upgrades deferred Phase 3 majors:

- **zod** 3→4 (shared/schemas)
- **@graphql-codegen/typescript** 4→5
- **@commitlint/cli** + **config-conventional** 19→20
- **lint-staged** 15→16

CI passes. No code changes required for zod 4 compatibility.

Made with [Cursor](https://cursor.com)